### PR TITLE
Time variants for skyblocks

### DIFF
--- a/src/main/java/code/elix_x/mods/skyblocks/SkyblocksBase.java
+++ b/src/main/java/code/elix_x/mods/skyblocks/SkyblocksBase.java
@@ -57,7 +57,7 @@ public class SkyblocksBase implements IMod<SkyblocksBase, IProxy<SkyblocksBase>>
 
 		for(boolean rel : relative) for(int t : times){
 			ResourceLocation reg = new ResourceLocation(SKYBLOCK.getResourceDomain(), String.format("%s_%s_%s", SKYBLOCK.getResourcePath(), rel ? "relative" : "fixed", t));
-			SkyBlock skyblock = (SkyBlock) new SkyBlock(t, rel).setRegistryName(reg);
+			Block skyblock = new SkyBlock(t, rel).setRegistryName(reg);
 			skyblocks.add(skyblock);
 			skyblockItems.add(new ItemBlockSkyblock(skyblock).setRegistryName(reg));
 		}

--- a/src/main/java/code/elix_x/mods/skyblocks/block/SkyBlock.java
+++ b/src/main/java/code/elix_x/mods/skyblocks/block/SkyBlock.java
@@ -3,17 +3,11 @@ package code.elix_x.mods.skyblocks.block;
 import code.elix_x.mods.skyblocks.tile.SkyblockTileEntity;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
-import net.minecraft.block.properties.IProperty;
-import net.minecraft.block.properties.PropertyBool;
-import net.minecraft.block.properties.PropertyInteger;
 import net.minecraft.block.state.BlockFaceShape;
-import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
-import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
-import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
@@ -21,43 +15,22 @@ import net.minecraft.world.World;
 public class SkyBlock extends Block {
 
 	public static final int TIMEINTERVAL = 6000;
-	public static final IProperty<Integer> TIME = PropertyInteger.create("time", 0, 3);
-	public static final IProperty<Boolean> FIXED = PropertyBool.create("fixed");
 
-	public SkyBlock(){
+	protected int time;
+	protected boolean relative;
+
+	public SkyBlock(int time, boolean relative){
 		super(Material.CLOTH);
+		this.time = time;
+		this.relative = relative;
+
 		setUnlocalizedName("skyblock");
 		setCreativeTab(CreativeTabs.DECORATIONS);
 		setLightOpacity(0);
 	}
 
-	@Override
-	protected BlockStateContainer createBlockState(){
-		return new BlockStateContainer(this, TIME, FIXED);
-	}
-
-	@Override
-	public int getMetaFromState(IBlockState state){
-		return ((state.getValue(FIXED) ? 1 : 0) << 2) | state.getValue(TIME);
-	}
-
-	@Override
-	public IBlockState getStateFromMeta(int meta){
-		return getDefaultState().withProperty(FIXED, (meta & 0b0100) != 0).withProperty(TIME, meta & 0b0011);
-	}
-
-	@Override
-	public int damageDropped(IBlockState state){
-		return getMetaFromState(state);
-	}
-
-	@Override
-	public void getSubBlocks(CreativeTabs itemIn, NonNullList<ItemStack> items){
-		for(boolean fixed : FIXED.getAllowedValues()) for(int time : TIME.getAllowedValues()) items.add(new ItemStack(this, 1, getMetaFromState(getDefaultState().withProperty(FIXED, fixed).withProperty(TIME, time))));
-	}
-
 	public int getSkyblockTime(World world, IBlockState state){
-		return (state.getValue(FIXED) ? 0 : (int) world.getWorldTime()) + state.getValue(TIME) * TIMEINTERVAL;
+		return (relative ? (int) world.getWorldTime() : 0) + time;
 	}
 
 	@Override

--- a/src/main/java/code/elix_x/mods/skyblocks/block/SkyBlock.java
+++ b/src/main/java/code/elix_x/mods/skyblocks/block/SkyBlock.java
@@ -3,22 +3,57 @@ package code.elix_x.mods.skyblocks.block;
 import code.elix_x.mods.skyblocks.tile.SkyblockTileEntity;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.properties.PropertyBool;
+import net.minecraft.block.properties.PropertyInteger;
 import net.minecraft.block.state.BlockFaceShape;
+import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
 public class SkyBlock extends Block {
 
+	public static final int TIMEINTERVAL = 6000;
+	public static final IProperty<Integer> TIME = PropertyInteger.create("time", 0, 3);
+	public static final IProperty<Boolean> FIXED = PropertyBool.create("fixed");
+
 	public SkyBlock(){
 		super(Material.CLOTH);
 		setUnlocalizedName("skyblock");
 		setCreativeTab(CreativeTabs.DECORATIONS);
 		setLightOpacity(0);
+	}
+
+	@Override
+	protected BlockStateContainer createBlockState(){
+		return new BlockStateContainer(this, TIME, FIXED);
+	}
+
+	@Override
+	public int getMetaFromState(IBlockState state){
+		return ((state.getValue(FIXED) ? 1 : 0) << 2) | state.getValue(TIME);
+	}
+
+	@Override
+	public IBlockState getStateFromMeta(int meta){
+		return getDefaultState().withProperty(FIXED, (meta & 0b0100) != 0).withProperty(TIME, meta & 0b0011);
+	}
+
+	@Override
+	public int damageDropped(IBlockState state){
+		return getMetaFromState(state);
+	}
+
+	@Override
+	public void getSubBlocks(CreativeTabs itemIn, NonNullList<ItemStack> items){
+		for(boolean fixed : FIXED.getAllowedValues()) for(int time : TIME.getAllowedValues()) items.add(new ItemStack(this, 1, getMetaFromState(getDefaultState().withProperty(FIXED, fixed).withProperty(TIME, time))));
 	}
 
 	@Override
@@ -40,4 +75,5 @@ public class SkyBlock extends Block {
 	public BlockFaceShape getBlockFaceShape(IBlockAccess world, IBlockState state, BlockPos pos, EnumFacing side){
 		return side == EnumFacing.UP ? BlockFaceShape.UNDEFINED : BlockFaceShape.SOLID;
 	}
+
 }

--- a/src/main/java/code/elix_x/mods/skyblocks/block/SkyBlock.java
+++ b/src/main/java/code/elix_x/mods/skyblocks/block/SkyBlock.java
@@ -56,6 +56,10 @@ public class SkyBlock extends Block {
 		for(boolean fixed : FIXED.getAllowedValues()) for(int time : TIME.getAllowedValues()) items.add(new ItemStack(this, 1, getMetaFromState(getDefaultState().withProperty(FIXED, fixed).withProperty(TIME, time))));
 	}
 
+	public int getSkyblockTime(World world, IBlockState state){
+		return (state.getValue(FIXED) ? 0 : (int) world.getWorldTime()) + state.getValue(TIME) * TIMEINTERVAL;
+	}
+
 	@Override
 	public boolean hasTileEntity(IBlockState state){
 		return true;

--- a/src/main/java/code/elix_x/mods/skyblocks/block/SkyBlock.java
+++ b/src/main/java/code/elix_x/mods/skyblocks/block/SkyBlock.java
@@ -29,6 +29,14 @@ public class SkyBlock extends Block {
 		setLightOpacity(0);
 	}
 
+	public int getTime(){
+		return time;
+	}
+
+	public boolean isRelative(){
+		return relative;
+	}
+
 	public int getSkyblockTime(World world, IBlockState state){
 		return (relative ? (int) world.getWorldTime() : 0) + time;
 	}

--- a/src/main/java/code/elix_x/mods/skyblocks/client/renderer/SkyblockTileEntityRenderer.java
+++ b/src/main/java/code/elix_x/mods/skyblocks/client/renderer/SkyblockTileEntityRenderer.java
@@ -21,6 +21,7 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.util.glu.Project;
@@ -99,6 +100,11 @@ public class SkyblockTileEntityRenderer extends TileEntitySpecialRenderer<Skyblo
 		if(!skyblocks.isEmpty()) skyblocks.keySet().forEach(time -> WTWRenderer.Phase.STENCIL.render(() -> renderStencil(time, event.getPartialTicks()), () -> renderSky(time, event.getPartialTicks())));
 	}
 
+	@SubscribeEvent(priority = EventPriority.LOWEST)
+	public void postWTWRender(RenderWorldLastEvent event){
+		skyblocks.clear();
+	}
+
 	private void renderStencil(int time, float partialTicks){
 		GlStateManager.pushMatrix();
 		GlStateManager.disableTexture2D();
@@ -106,7 +112,7 @@ public class SkyblockTileEntityRenderer extends TileEntitySpecialRenderer<Skyblo
 		Tessellator tess = Tessellator.getInstance();
 		BufferBuilder buffer = tess.getBuffer();
 		buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION);
-		skyblocks.removeAll(time).forEach(consumer -> consumer.accept(buffer));
+		skyblocks.get(time).forEach(consumer -> consumer.accept(buffer));
 		tess.draw();
 		GlStateManager.disableBlend();
 		GlStateManager.enableTexture2D();

--- a/src/main/java/code/elix_x/mods/skyblocks/client/renderer/SkyblockTileEntityRenderer.java
+++ b/src/main/java/code/elix_x/mods/skyblocks/client/renderer/SkyblockTileEntityRenderer.java
@@ -96,31 +96,10 @@ public class SkyblockTileEntityRenderer extends TileEntitySpecialRenderer<Skyblo
 
 	@SubscribeEvent
 	public void renderLast(RenderWorldLastEvent event){
-		if(!skyblocks.isEmpty()){
-			if(false) WTWRenderer.render(() -> {}, () -> {if(false) writeGlobalDepth(event.getPartialTicks());});
-			skyblocks.keySet().forEach(time -> WTWRenderer.render(() -> renderStencil(time, event.getPartialTicks()), () -> renderSky(time, event.getPartialTicks())));
-			skyblocks.clear();
-		}
-	}
-
-	private void writeGlobalDepth(float partialTicks){
-		GlStateManager.colorMask(false, false, false, false);
-		GlStateManager.pushMatrix();
-		GlStateManager.disableTexture2D();
-		GlStateManager.enableBlend();
-		Tessellator tess = Tessellator.getInstance();
-		BufferBuilder buffer = tess.getBuffer();
-		buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION);
-		skyblocks.values().forEach(consumer -> consumer.accept(buffer));
-		tess.draw();
-		GlStateManager.disableBlend();
-		GlStateManager.enableTexture2D();
-		GlStateManager.popMatrix();
-		GlStateManager.colorMask(true, true, true, true);
+		if(!skyblocks.isEmpty()) skyblocks.keySet().forEach(time -> WTWRenderer.render(() -> renderStencil(time, event.getPartialTicks()), () -> renderSky(time, event.getPartialTicks())));
 	}
 
 	private void renderStencil(int time, float partialTicks){
-		GlStateManager.depthFunc(GL11.GL_EQUAL);
 		GlStateManager.pushMatrix();
 		GlStateManager.disableTexture2D();
 		GlStateManager.enableBlend();
@@ -132,7 +111,6 @@ public class SkyblockTileEntityRenderer extends TileEntitySpecialRenderer<Skyblo
 		GlStateManager.disableBlend();
 		GlStateManager.enableTexture2D();
 		GlStateManager.popMatrix();
-		GlStateManager.depthFunc(GL11.GL_LEQUAL);
 	}
 
 	private void renderSky(int time, float partialTicks){
@@ -142,6 +120,7 @@ public class SkyblockTileEntityRenderer extends TileEntitySpecialRenderer<Skyblo
 		float fov = entityRenderer.<Float> getDeclaredMethod(new String[]{"getFOVModifier", "func_78481_a"}, float.class, boolean.class).setAccessible(true).invoke(renderer, partialTicks, true);
 
 		GlStateManager.pushMatrix();
+		GlStateManager.depthMask(false);
 
 		new AClass<>(EntityRenderer.class).getDeclaredMethod(new String[]{"setupFog", "func_78468_a"}, int.class, float.class).setAccessible(true).invoke(renderer, -1, partialTicks);
 
@@ -191,6 +170,7 @@ public class SkyblockTileEntityRenderer extends TileEntitySpecialRenderer<Skyblo
 
 		GlStateManager.disableFog();
 		GlStateManager.depthFunc(GL11.GL_LEQUAL);
+		GlStateManager.depthMask(true);
 
 		GlStateManager.matrixMode(GL11.GL_PROJECTION);
 		GlStateManager.loadIdentity();

--- a/src/main/java/code/elix_x/mods/skyblocks/item/ItemBlockSkyblock.java
+++ b/src/main/java/code/elix_x/mods/skyblocks/item/ItemBlockSkyblock.java
@@ -1,7 +1,14 @@
 package code.elix_x.mods.skyblocks.item;
 
+import code.elix_x.mods.skyblocks.block.SkyBlock;
 import net.minecraft.block.Block;
+import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+import javax.annotation.Nullable;
+import java.util.List;
 
 public class ItemBlockSkyblock extends ItemBlock {
 
@@ -16,4 +23,8 @@ public class ItemBlockSkyblock extends ItemBlock {
 		return hasSubtypes ? damage : 0;
 	}
 
+	@Override
+	public void addInformation(ItemStack stack, @Nullable World worldIn, List<String> tooltip, ITooltipFlag flagIn){
+		tooltip.add(String.format("t%s%s", ((SkyBlock) getBlock()).isRelative() ? "+" : "=", ((SkyBlock) getBlock()).getTime()));
+	}
 }

--- a/src/main/java/code/elix_x/mods/skyblocks/proxy/ClientProxy.java
+++ b/src/main/java/code/elix_x/mods/skyblocks/proxy/ClientProxy.java
@@ -39,15 +39,15 @@ public class ClientProxy implements IProxy<SkyblocksBase> {
 
 	@SubscribeEvent
 	public static void registerModels(ModelRegistryEvent event){
-		ModelLoader.setCustomStateMapper(SkyblocksBase.INSTANCE.skyblock, new StateMapperBase() {
+		SkyblocksBase.INSTANCE.skyblocks.forEach(skyblock -> ModelLoader.setCustomStateMapper(skyblock, new StateMapperBase(){
 
 			@Override
 			protected ModelResourceLocation getModelResourceLocation(IBlockState state){
 				return new ModelResourceLocation(SkyblocksBase.SKYBLOCK, "normal");
 			}
 
-		});
-		for(int i = 0; i < 8; i++) ModelLoader.setCustomModelResourceLocation(SkyblocksBase.INSTANCE.skyblockItem, i, new ModelResourceLocation(SkyblocksBase.SKYBLOCK, "normal"));
+		}));
+		SkyblocksBase.INSTANCE.skyblockItems.forEach(item -> ModelLoader.setCustomModelResourceLocation(item, 0, new ModelResourceLocation(SkyblocksBase.SKYBLOCK, "normal")));
 	}
 
 }

--- a/src/main/java/code/elix_x/mods/skyblocks/proxy/ClientProxy.java
+++ b/src/main/java/code/elix_x/mods/skyblocks/proxy/ClientProxy.java
@@ -4,8 +4,10 @@ import code.elix_x.excore.utils.proxy.IProxy;
 import code.elix_x.mods.skyblocks.SkyblocksBase;
 import code.elix_x.mods.skyblocks.client.renderer.SkyblockTileEntityRenderer;
 import code.elix_x.mods.skyblocks.tile.SkyblockTileEntity;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.client.renderer.block.statemap.StateMapperBase;
 import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
@@ -37,7 +39,15 @@ public class ClientProxy implements IProxy<SkyblocksBase> {
 
 	@SubscribeEvent
 	public static void registerModels(ModelRegistryEvent event){
-		ModelLoader.setCustomModelResourceLocation(SkyblocksBase.INSTANCE.skyblockItem, 0, new ModelResourceLocation(SkyblocksBase.SKYBLOCK, "normal"));
+		ModelLoader.setCustomStateMapper(SkyblocksBase.INSTANCE.skyblock, new StateMapperBase() {
+
+			@Override
+			protected ModelResourceLocation getModelResourceLocation(IBlockState state){
+				return new ModelResourceLocation(SkyblocksBase.SKYBLOCK, "normal");
+			}
+
+		});
+		for(int i = 0; i < 8; i++) ModelLoader.setCustomModelResourceLocation(SkyblocksBase.INSTANCE.skyblockItem, i, new ModelResourceLocation(SkyblocksBase.SKYBLOCK, "normal"));
 	}
 
 }

--- a/src/main/java/code/elix_x/mods/skyblocks/tile/SkyblockTileEntity.java
+++ b/src/main/java/code/elix_x/mods/skyblocks/tile/SkyblockTileEntity.java
@@ -1,10 +1,17 @@
 package code.elix_x.mods.skyblocks.tile;
 
+import code.elix_x.mods.skyblocks.block.SkyBlock;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class SkyblockTileEntity extends TileEntity {
+
+	public int getSkyblockTime(){
+		IBlockState state = getBlockType().getStateFromMeta(getBlockMetadata());
+		return (state.getValue(SkyBlock.FIXED) ? 0 : (int) world.getWorldTime()) + state.getValue(SkyBlock.TIME) * SkyBlock.TIMEINTERVAL;
+	}
 
 	@Override
 	@SideOnly(Side.CLIENT)

--- a/src/main/java/code/elix_x/mods/skyblocks/tile/SkyblockTileEntity.java
+++ b/src/main/java/code/elix_x/mods/skyblocks/tile/SkyblockTileEntity.java
@@ -1,6 +1,6 @@
 package code.elix_x.mods.skyblocks.tile;
 
-import code.elix_x.mods.skyblocks.block.SkyBlock;
+import code.elix_x.mods.skyblocks.SkyblocksBase;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.fml.relauncher.Side;
@@ -10,7 +10,7 @@ public class SkyblockTileEntity extends TileEntity {
 
 	public int getSkyblockTime(){
 		IBlockState state = getBlockType().getStateFromMeta(getBlockMetadata());
-		return (state.getValue(SkyBlock.FIXED) ? 0 : (int) world.getWorldTime()) + state.getValue(SkyBlock.TIME) * SkyBlock.TIMEINTERVAL;
+		return SkyblocksBase.INSTANCE.skyblock.getSkyblockTime(world, state);
 	}
 
 	@Override

--- a/src/main/java/code/elix_x/mods/skyblocks/tile/SkyblockTileEntity.java
+++ b/src/main/java/code/elix_x/mods/skyblocks/tile/SkyblockTileEntity.java
@@ -1,6 +1,6 @@
 package code.elix_x.mods.skyblocks.tile;
 
-import code.elix_x.mods.skyblocks.SkyblocksBase;
+import code.elix_x.mods.skyblocks.block.SkyBlock;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.fml.relauncher.Side;
@@ -10,7 +10,7 @@ public class SkyblockTileEntity extends TileEntity {
 
 	public int getSkyblockTime(){
 		IBlockState state = getBlockType().getStateFromMeta(getBlockMetadata());
-		return SkyblocksBase.INSTANCE.skyblock.getSkyblockTime(world, state);
+		return ((SkyBlock) state.getBlock()).getSkyblockTime(world, state);
 	}
 
 	@Override


### PR DESCRIPTION
Created skyblock time variants - one variant for each fixed time of day (morning, noon, evening, midnight) and 4 variants each displaying the sky relative to the current time (current, +¼ day, +½ day, +¾ day).
Each is a different block - according to future changes in 1.13.

Check #6 - it should be fixed.